### PR TITLE
added optional limiting of DragScroll to certain classes

### DIFF
--- a/js/jquery.dragscroll.js
+++ b/js/jquery.dragscroll.js
@@ -16,12 +16,15 @@
         $($scrollArea).attr("onselectstart", "return false;");   // Disable text selection in IE8
 
         $($scrollArea).mousedown(function (e) {
-            e.preventDefault();
-            down = true;
-            x = e.pageX;
-            y = e.pageY;
-            top = $(this).scrollTop();
-            left = $(this).scrollLeft();
+            if(typeof options.limitTo == "object") {
+                for(var i = 0; i < options.limitTo.length; i++) {
+                    if($(e.target).hasClass(options.limitTo[i])) {
+                        doMousedown(e);
+                    }
+                }
+            } else {
+                doMousedown(e);
+            }
         });
         $($scrollArea).mouseleave(function (e) {
             down = false;
@@ -35,5 +38,14 @@
             }
         });
         $("body").mouseup(function (e) { down = false; });
+
+        function doMousedown(e) {
+            e.preventDefault();
+            down = true;
+            x = e.pageX;
+            y = e.pageY;
+            top = $(this).scrollTop();
+            left = $(this).scrollLeft();
+        }
     };
 })(jQuery);


### PR DESCRIPTION
Added a way to limit the DragScroll functionality to the classes you
specify.

Use case:
When there’s an element that’s draggable, you don’t want to be
scrolling while you’re dragging.

Example:
$('.view').dragScroll({
limitTo: ['view’, ‘list’]
});

Weaknesses:
If you’re using the limitTo option, you need to make sure you specify
the parent class and any other class you want DraggScroll to be enabled
on
