### PR TITLE
Fixed bug where scroll would reset on mouse move

### DIFF
--- a/js/jquery.dragscroll.js
+++ b/js/jquery.dragscroll.js
@@ -44,8 +44,8 @@
             down = true;
             x = e.pageX;
             y = e.pageY;
-            top = $(this).scrollTop();
-            left = $(this).scrollLeft();
+            top = $($scrollArea).scrollTop();
+            left = $($scrollArea).scrollLeft();
         }
     };
 })(jQuery);


### PR DESCRIPTION
If you had some content and tried to scroll it, then left the area, then tried to scroll again, the scroll would reset every time. Thus, you would be able to scroll only content that is less than 3 x your window width and 3 x your window height.

By keeping track of current scroll in the scroll area, this problem is solved.
